### PR TITLE
Add check for ToxicFallout to GetWeightedApparelStats

### DIFF
--- a/Source/Outfitter/ApparelStatsHelper.cs
+++ b/Source/Outfitter/ApparelStatsHelper.cs
@@ -95,6 +95,11 @@ namespace Outfitter
                     }
                 }
 
+                if (Find.MapConditionManager.ConditionIsActive(MapConditionDef.Named("ToxicFallout")))
+                {
+                    dict.Add(StatDefOf.ToxicSensitivity, -1f);
+                }
+
                 foreach (StatDef key in new List<StatDef>(dict.Keys))
                 {
                     if (key == StatDefOf.MoveSpeed)


### PR DESCRIPTION
This commit adds a weight for `ToxicSensitivity` if the map has ToxicFallout. While nothing in Core modifies `ToxicSensitivity`, mods such as FashionRIMsta adds apparel with a modifier to this Stat (e.g. a gas mask).

I did a little guesstimating when setting the weight, but -1 seems reasonable. In my brief tests with the FashionRIMsta, it makes the colonists go fetch gas masks when the Toxic Fallout event triggers, and removing them afterward (if there are other desirable hats/helmets).